### PR TITLE
Upgrade github workflow to support darwin/arm64

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
         name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.17.3
       - 
         name: Create release on GitHub
         uses: goreleaser/goreleaser-action@v2


### PR DESCRIPTION
This should address the issue with darwin/arm64: https://github.com/timohirt/terraform-provider-hetznerdns/issues/29 

Reference:
https://goreleaser.com/deprecations/#builds-for-darwinarm64 
