### PR TITLE
[bump] go module to "v2"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/timohirt/terraform-provider-hetznerdns
+module github.com/timohirt/terraform-provider-hetznerdns/v2
 
 go 1.16
 

--- a/hetznerdns/data_source_zone.go
+++ b/hetznerdns/data_source_zone.go
@@ -3,7 +3,7 @@ package hetznerdns
 import (
 	"fmt"
 
-	"github.com/timohirt/terraform-provider-hetznerdns/hetznerdns/api"
+	"github.com/timohirt/terraform-provider-hetznerdns/v2/hetznerdns/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/hetznerdns/provider.go
+++ b/hetznerdns/provider.go
@@ -2,7 +2,7 @@ package hetznerdns
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/timohirt/terraform-provider-hetznerdns/hetznerdns/api"
+	"github.com/timohirt/terraform-provider-hetznerdns/v2/hetznerdns/api"
 )
 
 // Provider creates and return a Terraform resource provider

--- a/hetznerdns/resource_record.go
+++ b/hetznerdns/resource_record.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/timohirt/terraform-provider-hetznerdns/hetznerdns/api"
+	"github.com/timohirt/terraform-provider-hetznerdns/v2/hetznerdns/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/hetznerdns/resource_zone.go
+++ b/hetznerdns/resource_zone.go
@@ -3,7 +3,7 @@ package hetznerdns
 import (
 	"log"
 
-	"github.com/timohirt/terraform-provider-hetznerdns/hetznerdns/api"
+	"github.com/timohirt/terraform-provider-hetznerdns/v2/hetznerdns/api"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	plugin "github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
-	"github.com/timohirt/terraform-provider-hetznerdns/hetznerdns"
+	"github.com/timohirt/terraform-provider-hetznerdns/v2/hetznerdns"
 )
 
 func main() {


### PR DESCRIPTION
Hey,

I'm currently developing a Pulumi Provider wrapping this Terraform Provider. Therefore I want to follow the go modules semantic and bump this module to `v2`.

Best regards
icepuma