### PR TITLE
fix: typo in resource description

### DIFF
--- a/docs/resources/hetznerdns_record.md
+++ b/docs/resources/hetznerdns_record.md
@@ -1,6 +1,6 @@
 # hetznerdns_record Resource
 
-Provides a Hetzner DNS Recrods resource to create, update and delete DNS Records.
+Provides a Hetzner DNS Records resource to create, update and delete DNS Records.
 
 ## Example Usage
 


### PR DESCRIPTION
Originally #47. Moved here because integration tests require secrets only available in this repository.