### PR TITLE
fix: document correct curl usage

### DIFF
--- a/docs/resources/hetznerdns_record.md
+++ b/docs/resources/hetznerdns_record.md
@@ -43,7 +43,7 @@ a zone and then copy the id.
 
 ```
 curl "https://dns.hetzner.com/api/v1/records" \
-     -H 'Auth-API-Token: $HETZNER_DNS_API_TOKEN' | jq .
+     -H "Auth-API-Token: $HETZNER_DNS_API_TOKEN" | jq .
 
 {
   "records": [


### PR DESCRIPTION
You need to use double quotes for variables to expand.